### PR TITLE
Proxy AR scraper requests

### DIFF
--- a/.github/workflows/fetch_stats.yml
+++ b/.github/workflows/fetch_stats.yml
@@ -67,8 +67,10 @@ jobs:
           
       - name: execute py script 
         run: |
-          echo "PYTHONPATH=src" >> $GITHUB_ENV
           python src/nsofetch/fetch_${{ matrix.country }}.py ${{ matrix.index }}
+        env:
+          PYTHONPATH: src
+          PROXY_URL: ${{ secrets.PROXY_URL }}
 
       - name: Save scraper output
         uses: actions/upload-artifact@v3

--- a/src/nsofetch/fetch_ar.py
+++ b/src/nsofetch/fetch_ar.py
@@ -1,3 +1,4 @@
+import os
 import pandas
 import requests
 
@@ -8,8 +9,12 @@ import filepaths
 def fetch_ar_inflation_cpi():
     stats_metadata = utils.read_stats_metadata()
 
+    proxies = {
+        "http": os.environ["PROXY_URL"],
+        "https": os.environ["PROXY_URL"],
+    }
     url = stats_metadata["AR"]["inflation"]["CPI"]["url"]
-    response = requests.get(url)
+    response = requests.get(url, proxies=proxies)
     response.raise_for_status()
     stats = response.json()
 


### PR DESCRIPTION
Fixes #11.

GitHub Actions runs on some cloud platform (Microsoft Azure I think) which looks to be blocked by apis.datos.gob.ar.

Proxying via proxy.fullfact.org fixes the problem.