### PR TITLE
fix: duplicate title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![fetch-stats](https://github.com/FullFact/nso-stats-fetcher/actions/workflows/fetch_stats.yml/badge.svg)](https://github.com/FullFact/nso-stats-fetcher/actions/workflows/fetch_stats.yml)
 
-# National Statistical Offices Statistics Fetcher
 Fetches and cleans data from NSO websites and publishes them as in a standardised [tidy data](https://cran.r-project.org/web/packages/tidyr/vignettes/tidy-data.html) format. 
 
 This work has two goals

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+title: National Statistical Offices Statistics Fetcher
 exclude:
   - src/
   - poetry.lock


### PR DESCRIPTION
Fixes #20.

Unfortunately this does also remove the title from the README, which is a bit sad. There’s no way around that without using separate files for the two things.