### PR TITLE
fix: Also removing Argentina from config file

### DIFF
--- a/.github/workflows/fetch_stats.yml
+++ b/.github/workflows/fetch_stats.yml
@@ -24,8 +24,8 @@ jobs:
             index: rpi
           - country: ie
             index: cpi
-          - country: ar
-            index: cpi
+          # - country: ar
+          #   index: cpi
           - country: za
             index: cpi
           - country: za


### PR DESCRIPTION
Fixes https://linear.app/fullfact/issue/AI-1576/stats-fetcher-argentinian-data-not-available

Config file was still triggering Argentine data scrape; that's now removed too

-----------------

## Pull request checklist

- [x] I have linked my PR to an issue 
- [x] I’ve used [conventional commits](https://github.com/FullFact/automation-docs/wiki/Conventional-commits)
- [x] My branch is up-to-date with `main`
- [x] Where appropriate, I have added or updated tests
- [x] Where appropriate, I have [updated documentation](https://github.com/FullFact/automation-docs/) to reflect my changes
